### PR TITLE
Search for CVO/TMBtrace files recusively

### DIFF
--- a/R/cnv.R
+++ b/R/cnv.R
@@ -42,6 +42,7 @@ read_cnv_data <- function(cnv_directory, local_app=FALSE){
   cnv_files <- list.files(
     path = cnv_directory,
     pattern = "*cnv.vcf|*CopyNumberVariants.vcf",
+    recursive = TRUE,
     full.names = TRUE
   )
   cnv_data <- map(cnv_files, cnv, local_app)  %>%
@@ -61,6 +62,7 @@ summarize_cnv_data <- function(cnv_directory){
   cnv_files <- list.files(
     path = cnv_directory,
     pattern = "*cnv.vcf|*CopyNumberVariants.vcf",
+    recursive = TRUE,
     full.names = TRUE
   )
 

--- a/R/cvo.R
+++ b/R/cvo.R
@@ -74,6 +74,7 @@ read_cvo_data <- function(cvo_directory, local_app=FALSE){
   cvo_files <- list.files(
     path = cvo_directory,
     pattern = "*CombinedVariantOutput.tsv",
+    recursive = TRUE,
     full.names = TRUE
   )
   cvo_data <- map(cvo_files, cvo, local_app)

--- a/R/tmb.R
+++ b/R/tmb.R
@@ -23,6 +23,7 @@ read_tmb_trace_data <- function(tmb_directory){
   tmb_files <- list.files(
     path = tmb_directory,
     pattern = "*TMB_Trace.tsv",
+    recursive = TRUE,
     full.names = TRUE
   )
   


### PR DESCRIPTION
Useful for specifying a DRAGEN output folder, where CombinedVariantOutput.tsv files are organized in subfolders by sample.