### PR TITLE
Bugfix for DVC

### DIFF
--- a/R/cnv.R
+++ b/R/cnv.R
@@ -41,7 +41,7 @@ new_cnv_output <- function(cnv_file_path, local_app=FALSE) {
 read_cnv_data <- function(cnv_directory, local_app=FALSE){
   cnv_files <- list.files(
     path = cnv_directory,
-    pattern = "*cnv.vcf|*CopyNumberVariants.vcf",
+    pattern = "*cnv\\.vcf$|*CopyNumberVariants\\.vcf$",
     recursive = TRUE,
     full.names = TRUE
   )
@@ -61,7 +61,7 @@ read_cnv_data <- function(cnv_directory, local_app=FALSE){
 summarize_cnv_data <- function(cnv_directory){
   cnv_files <- list.files(
     path = cnv_directory,
-    pattern = "*cnv.vcf|*CopyNumberVariants.vcf",
+    pattern = "*cnv\\.vcf$|*CopyNumberVariants\\.vcf$",
     recursive = TRUE,
     full.names = TRUE
   )
@@ -69,7 +69,7 @@ summarize_cnv_data <- function(cnv_directory){
   cnv_data = tibble(file = cnv_files) %>%
     mutate(data = lapply(file, parse_vcf_to_df)) %>%
     unnest(data) %>%
-    mutate(sample_id = str_replace(basename(file), "_CopyNumberVariants.vcf", "")) %>%
+    mutate(sample_id = str_replace(basename(file), "_CopyNumberVariants\\.vcf$", "")) %>%
     select(-file) %>%
     relocate(sample_id)
 

--- a/R/cvo.R
+++ b/R/cvo.R
@@ -78,7 +78,7 @@ validate_tso500 <- function() {}
 read_cvo_data <- function(cvo_directory, local_app=FALSE, ctdna=FALSE){
   cvo_files <- list.files(
     path = cvo_directory,
-    pattern = "*CombinedVariantOutput.tsv",
+    pattern = "*CombinedVariantOutput\\.tsv$",
     recursive = TRUE,
     full.names = TRUE
   )

--- a/R/qualitymetrics.R
+++ b/R/qualitymetrics.R
@@ -69,7 +69,7 @@ validate_tso500_qc <- function() {}
 read_qmo_data <- function(qmo_directory, local_app=FALSE, ctdna=FALSE){
   qmo_files <- list.files(
     path = qmo_directory,
-    pattern = "*MetricsOutput.tsv",
+    pattern = "*MetricsOutput\\.tsv$",
     full.names = TRUE
   )
   

--- a/R/tmb.R
+++ b/R/tmb.R
@@ -22,7 +22,7 @@ tmb <- function(tmb_file_path){
 read_tmb_trace_data <- function(tmb_directory){
   tmb_files <- list.files(
     path = tmb_directory,
-    pattern = "*TMB_Trace.tsv|tmb.trace.tsv",
+    pattern = "*TMB_Trace\\.tsv$|tmb.trace\\.tsv$",
     recursive = TRUE,
     full.names = TRUE
   )


### PR DESCRIPTION
This bugfix handles issues with dvc files. The regex has been extended to specifically look for output files that end with *.tsv ($ ensures this is the end of the string in the pattern). 

This resolves breaking with *.tsv.dvc files created when using data version control. Might be required in other cases too, will give it a try.