### PR TITLE
Fix qc table for contamination p-value

### DIFF
--- a/R/qualitymetrics.R
+++ b/R/qualitymetrics.R
@@ -449,66 +449,96 @@ trim_qmo_header_and_footer <- function(string){
 #' @importFrom tidyr pivot_wider replace_na
 #' @export
 make_qc_table <- function(qc_df, id_col = "sample_id", group_name = "samples") {
-    # lower QC limit for each metric.
-    lsl <- qc_df |>
-        filter((!!sym(id_col)) == "lsl_guideline") |>
-        mutate(n_failed = NA) |>
-        distinct()
-    stopifnot(nrow(lsl) == 1)
+  # field names for contamination qc
+  p_value_field <- "CONTAMINATION_P_VALUE (NA)"
+  contamination_field <- "CONTAMINATION_SCORE (NA)"
+  
+  # lower QC limit for each metric.
+  lsl <- qc_df |>
+      filter((!!sym(id_col)) == "lsl_guideline") |>
+      mutate(n_failed = NA) |>
+      distinct()
+  stopifnot(nrow(lsl) == 1)
 
-    # upper QC limit for each metric
-    usl <- qc_df |>
-        filter((!!sym(id_col)) == "usl_guideline") |>
-        mutate(n_failed = 0) |>
-        distinct()
-    stopifnot(nrow(usl) == 1)
+  # upper QC limit for each metric
+  usl <- qc_df |>
+      filter((!!sym(id_col)) == "usl_guideline") |>
+      mutate(n_failed = 0) |>
+      distinct()
+  stopifnot(nrow(usl) == 1)
 
-    # QC metrics for each sample
-    run_metrics_df <- qc_df |>
-        filter(!(!!sym(id_col)) %in% c("lsl_guideline", "usl_guideline"))
+  # QC metrics for each sample
+  run_metrics_df <- qc_df |>
+      filter(!(!!sym(id_col)) %in% c("lsl_guideline", "usl_guideline"))
 
-    # simple vector with all metrics
-    metrics <- colnames(select(run_metrics_df, -!!id_col))
+  # simple vector with all metrics
+  metrics <- colnames(select(run_metrics_df, -!!id_col))
 
-    # Count the numbers of QC failures
-    qc_failure_count <- rep(0, nrow(run_metrics_df))
-    names(qc_failure_count) <- run_metrics_df[[id_col]]
-    for (metric in metrics) {
+  # Count the numbers of QC failures
+  qc_failure_count <- rep(0, nrow(run_metrics_df))
+  names(qc_failure_count) <- run_metrics_df[[id_col]]
+  for (metric in metrics) {
+    # ignore contamination p value since it is only relevant in case of failed 
+    # contamination score
+    if (metric != p_value_field) {
+      if(metric == contamination_field & (p_value_field %in% metrics)) {
         qc_failure_count <- qc_failure_count +
-            replace_na(run_metrics_df[[metric]] < lsl[[metric]], 0) +
-            replace_na(run_metrics_df[[metric]] > usl[[metric]], 0)
+          replace_na(run_metrics_df[[metric]] < lsl[[metric]], 0) +
+          replace_na(run_metrics_df[[metric]] > usl[[metric]] & run_metrics_df[[p_value_field]] <= usl[[p_value_field]], 0)
+      }
+      else { 
+        qc_failure_count <- qc_failure_count +
+          replace_na(run_metrics_df[[metric]] < lsl[[metric]], 0) +
+          replace_na(run_metrics_df[[metric]] > usl[[metric]], 0)
+      }
     }
+  }
 
-    # Merge tables into one for GT
-    merged_table <- bind_rows(
-        lsl |> mutate(group = "thresholds"),
-        usl |> mutate(group = "thresholds"),
-        run_metrics_df |> mutate(group = group_name, n_failed = qc_failure_count)
-    )
+  # Merge tables into one for GT
+  merged_table <- bind_rows(
+      lsl |> mutate(group = "thresholds"),
+      usl |> mutate(group = "thresholds"),
+      run_metrics_df |> mutate(group = group_name, n_failed = qc_failure_count)
+  )
 
-    table_out <- merged_table |>
-        gt::gt(rowname_col = id_col, groupname_col = "group")
+  table_out <- merged_table |>
+      gt::gt(rowname_col = id_col, groupname_col = "group")
 
-    # Conditional formatting
-    for (metric in c(metrics, "n_failed")) {
-        table_out <- table_out |>
-            gt::data_color(
-                columns = metric,
-                rows = group == group_name,
-                fn = \(x) case_when(
-                    x < lsl[[metric]] ~ dTMCP::COLORS["LightBlue"],
-                    x > usl[[metric]] ~ dTMCP::COLORS["LightRed"],
-                    .default = "white"
-                )
-            )
-    }
-
-    # separate the "n_failed" column visually
+  # Conditional formatting
+  for (metric in c(metrics, "n_failed")) {
     table_out <- table_out |>
-        gt::tab_style(
-            style = gt::cell_borders(sides = "left", weight = "2px", color = "lightgrey"),
-            locations = gt::cells_body(columns = "n_failed")
-        )
+      gt::data_color(
+        columns = metric,
+        rows = group == group_name,
+        fn = \(x) {
+          p_value_available <- p_value_field %in% metrics
+          if(p_value_available) {
+            case_when(
+              metric == p_value_field ~ "white",
+              (p_value_available & metric == contamination_field & (x > usl[[metric]] & 
+                                                                      run_metrics_df[[p_value_field]] <= usl[[p_value_field]])) ~ dTMCP::COLORS["LightRed"],
+              (metric != contamination_field & x < lsl[[metric]]) ~ dTMCP::COLORS["LightBlue"],
+              (metric != contamination_field & x > usl[[metric]]) ~ dTMCP::COLORS["LightRed"],
+              .default = "white"
+            )
+          }
+          else {
+            case_when(
+              x < lsl[[metric]] ~ dTMCP::COLORS["LightBlue"],
+              x > usl[[metric]] ~ dTMCP::COLORS["LightRed"],
+              .default = "white"
+            )
+          }
+        }
+    )
+  }
 
-    table_out
+  # separate the "n_failed" column visually
+  table_out <- table_out |>
+      gt::tab_style(
+          style = gt::cell_borders(sides = "left", weight = "2px", color = "lightgrey"),
+          locations = gt::cells_body(columns = "n_failed")
+      )
+
+  table_out
 }

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ In order to load the `MetricsOutput.tsv` file or multiple such output files of a
 ```r
 # load the MetricsOutput.tsv file in a specific folder
 tso500_data_dir <- "/path/to/your/TSO500/analysis/output/data/"
-qmo_data <- read_qmo_data(test_path)
+qmo_data <- read_qmo_data(tso500_data_dir)
 ```
 
 In case you want to read in data that resulted from a `LocalApp` run, you need to set `local_app=TRUE` due to the (slight) differences between the file formats:
@@ -51,7 +51,7 @@ In case you want to read in data that resulted from a `LocalApp` run, you need t
 ```r
 # load the MetricsOutput.tsv file of a LocalApp run in a specific folder
 tso500_data_dir <- "/path/to/your/TSO500/analysis/output/data/"
-qmo_data <- read_qmo_data(test_path, local_app=TRUE)
+qmo_data <- read_qmo_data(tso500_data_dir, local_app=TRUE)
 ```
 
 In case you want to read in data that resulted from a `ctDNA analysis` run, you need to set `ctdna=TRUE` due to the (slight) differences between the file formats:
@@ -59,7 +59,7 @@ In case you want to read in data that resulted from a `ctDNA analysis` run, you 
 ```r
 # load the MetricsOutput.tsv file of a LocalApp run in a specific folder
 tso500_data_dir <- "/path/to/your/TSO500/analysis/output/data/"
-qmo_data <- read_qmo_data(test_path, ctdna=TRUE)
+qmo_data <- read_qmo_data(tso500_data_dir, ctdna=TRUE)
 ```
 
 This will produce a list of `combined.quality.metrics.output` objects, which can be further processed and contain all the information as given in the parsed files. Each section in the `CombinedVariantOutput` file can be accessed with standard list indexing. The `combined.quality.metrics.output` object in the last can be accessed via the corresponding file name (without extension). This will therfore probably be `MetricsOutput` in case you read in a metrics file of all samples of a run and will include sample identifiers (`sample1_MetricsOutput`) if you want to read in individual metrics file.
@@ -97,7 +97,7 @@ To load all `CombinedVariantOutput.tsv` files of a DRAGEN analysis run in a spec
 ```r
 # load all CombinedVariantOutput.tsv files of a LocalApp run in a specific folder
 cvo_data_dir <- "/path/to/your/TSO500/analysis/output/data/"
-cvo_data <- read_cvo_data(tso500_data_dir)
+cvo_data <- read_cvo_data(cvo_data_dir)
 ```
 
 In case you want to read in data that resulted from a `LocalApp` run, you need to set `local_app=TRUE` due to the (slight) differences between the file formats:
@@ -105,7 +105,7 @@ In case you want to read in data that resulted from a `LocalApp` run, you need t
 ```r
 # load all CombinedVariantOutput.tsv files in a specific folder
 cvo_data_dir <- "/path/to/your/TSO500/analysis/output/data/"
-cvo_data <- read_cvo_data(tso500_data_dir, local_app=TRUE)
+cvo_data <- read_cvo_data(cvo_data_dir, local_app=TRUE)
 ```
 
 In case you want to read in data that resulted from a `ctdna` pipeline run, you need to set `ctdna=TRUE` due to the (slight) differences between the file formats:
@@ -113,7 +113,7 @@ In case you want to read in data that resulted from a `ctdna` pipeline run, you 
 ```r
 # load all CombinedVariantOutput.tsv files in a specific folder
 cvo_data_dir <- "/path/to/your/TSO500/analysis/output/data/"
-cvo_data <- read_cvo_data(tso500_data_dir, ctdna=TRUE)
+cvo_data <- read_cvo_data(cvo_data_dir, ctdna=TRUE)
 ```
 
 This will produce a list of `combined.variant.output` objects, which can be further processed and contain all the information as given in the parsed files. Each section in the `CombinedVariantOutput` file can be accessed with standard list indexing. The individual `combined.variant.output` objects in the list can be accessed via the `PairID` as given in the `CombinedVariantOutput.tsv` file.


### PR DESCRIPTION
This fixes the qc table generation in cases where the contamination p-value is part of the qc metrics as well. This is only the case for some versions of the `MetricsOutput`.


From the documentation:
```
The contamination p-value used to assess highly rearranged genomes. 
A p‑value ≤ 0.049 suggests that the sample has large-scale rearrangements that could lead to high-contamination scores without actual sample contamination. 
The contamination p-value is only needed when the contamination score is above USL.
```

Fixes #29. 