### PR TITLE
Don't build docs on release events

### DIFF
--- a/.github/workflows/build_docs.yml
+++ b/.github/workflows/build_docs.yml
@@ -3,8 +3,6 @@ on:
   push:
     branches: [ main ]
   pull_request:
-  release:
-    types: [ published ]
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
Should be enough to build it on `main`